### PR TITLE
Bunch of renames to follow standard procedures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Ideas
 - Process monitoring
 - programatically compose a chain of streams.
 - process call timeouts
-- >>> uptime.std_out >> cowsay.std_in
+- >>> uptime.stdout >> cowsay.stdin
 
 Usage
 -----
@@ -23,11 +23,11 @@ Simple Usage::
     >>> import pipes
 
     >>> c = pipes.run('uptime')
-    >>> c.exit_code
+    >>> c.returncode
     0
     >>> c.ok
     True
-    >>> print c.std_out
+    >>> print c.stdout
     16:08  up  1:16, 7 users, load averages: 1.02 1.90 1.75
 
 
@@ -36,7 +36,7 @@ Advanced Usage::
     >>> chain = pipes.chain()
     >>> uptime = chain.process('uptime')
     >>> cowsay = chain.process('cowsay')
-    >>> chain.link(uptime.std_out, cowsay.std_in)
+    >>> chain.link(uptime.stdout, cowsay.stdin)
     >>> chain.start(wait=True)
     >>> chain.wait()
 

--- a/pipes.py
+++ b/pipes.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 
 
-
 class Process(object):
     def __init__(self, command):
         pass
@@ -11,16 +10,16 @@ class Process(object):
         pass
 
     @property
-    def std_in(self):
-        return 'std_in'
+    def stdin(self):
+        return 'stdin'
 
     @property
-    def std_out(self):
-        return 'std_out'
+    def stdout(self):
+        return 'stdout'
 
     @property
-    def std_err(self):
-        return 'std_err'
+    def stderr(self):
+        return 'stderr'
 
 
 class Chain(object):
@@ -41,8 +40,6 @@ class Chain(object):
         for process in self.processes:
             process.start()
             # wait=wait
-
-
 
 
 def chain():

--- a/usage.py
+++ b/usage.py
@@ -5,10 +5,10 @@ chain = pipes.chain()
 uptime = chain.process('uptime')
 cowsay = chain.process('cowsay')
 
-chain.link(uptime.std_out, cowsay.std_in)
+chain.link(uptime.stdout, cowsay.stdin)
 chain.start(wait=True)
 
-print cowsay.std_out
+print cowsay.stdout
 
 
 # ConnectedProcess


### PR DESCRIPTION
- Adresses #1 
- Renames standard streams to ones without the underscore.
- Retains subprocess' way of doing returncode as opposed to exit_code
- t.py doesn't make sense, calling it usage.py
